### PR TITLE
Use "meteor-spk build" not "meteor-spk spk"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To package your existing Meteor app, simply do the following:
    must be a member of the server's group. The tool will connect to that
    server and temporarily make your app available for testing. When done
    testing, use ctrl+C in the terminal to stop.
-4. Run `meteor-spk spk example.spk` to create a Sandstorm package file called
+4. Run `meteor-spk build example.spk` to create a Sandstorm package file called
    `example.spk`. WARNING: You may want to place this file outside of your
    source directory as otherwise Meteor will think it is part of the app
    and will include it in the app bundle. This means if you repeatedly run


### PR DESCRIPTION
Rationale:

```
➜  simple-todos git:(master) ✗ ~/bin/meteor-spk spk ../output.spk
spk: spk: unknown command
Try 'spk --help' for more information.
➜  simple-todos git:(master) ✗ ~/bin/meteor-spk spk ../output.spk
spk: spk: unknown command
Try 'spk --help' for more information.
➜  simple-todos git:(master) ✗ ~/bin/meteor-spk                  
Missing command. Try: /home/paulproteus/bin/meteor-spk help
➜  simple-todos git:(master) ✗ ~/bin/meteor-spk help
/home/paulproteus/bin/meteor-spk is much like Sandstorm's standard 'spk' tool except that it includes some
Meteor-specific shortcuts. In particular:
- You don't need to pass any arguments to 'init'.
- You don't need to worry about setting up a source map to define what is in
  your package. The 'dev' and 'pack' commands will automatically bundle your
  Meteor app together with everything that is needed.
➜  simple-todos git:(master) ✗ ~/bin/meteor-spk pack ../output.spk
Building Meteor app...
```
