### PR TITLE
Replace meteor bundle by meteor build

### DIFF
--- a/meteor-spk
+++ b/meteor-spk
@@ -68,7 +68,7 @@ bundle() {
   makedotdir
 
   echo "Building Meteor app..."
-  meteor bundle --directory .meteor-spk/bundle
+  meteor build --directory .meteor-spk/bundle
   (cd .meteor-spk/bundle/programs/server && "$METEOR_DEV_BUNDLE/bin/npm" install)
 }
 


### PR DESCRIPTION
meteor bundle command is deprecated since Meteor v0.9.2 and is causing a warning message in the console.
