### PR TITLE
Fix 'meteor build' invocation.

### DIFF
--- a/meteor-spk
+++ b/meteor-spk
@@ -68,7 +68,7 @@ bundle() {
   makedotdir
 
   echo "Building Meteor app..."
-  meteor build --directory .meteor-spk/bundle
+  meteor build --directory .meteor-spk
   (cd .meteor-spk/bundle/programs/server && "$METEOR_DEV_BUNDLE/bin/npm" install)
 }
 


### PR DESCRIPTION
Currently, `meteor-spk dev` makes a .meteor-spk/bundle/bundle directory, and then gets confused when it can't find a .meteor-spk/bundle/programs/server directory. This patch fixes things.
