### PR TITLE
Fix bug where fibers module fails to build if the system `node` is newer than v0.10.

### DIFF
--- a/meteor-spk
+++ b/meteor-spk
@@ -67,6 +67,11 @@ makedotdir() {
 bundle() {
   makedotdir
 
+  # The fibers module builds native extensions, choosing the target v8 version based on the version
+  # of `/usr/bin/env node`. We need to make sure that this matches the Meteor node binary that will
+  # be used in our package.
+  export PATH=$METEOR_DEV_BUNDLE/bin:$PATH
+
   echo "Building Meteor app..."
   meteor build --directory .meteor-spk
   (cd .meteor-spk/bundle/programs/server && "$METEOR_DEV_BUNDLE/bin/npm" install)


### PR DESCRIPTION
See https://github.com/laverdet/node-fibers/blob/master/build.js
