### PR TITLE
Bump the meteor version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-VERSION=0.5.1
-METEOR_VERSION=1.10.1
+VERSION=0.6.0
+METEOR_VERSION=2.3.5
 
 meteor-spk.deps: mongo/mongod niscu/mongod gather-deps.sh start.js
 	@echo "**** Gathering dependencies..."

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ way to do that is:
 ### Installing `meteor-spk` from binaries
 
 1. Download and unpack
-   [the binary distribution](https://dl.sandstorm.io/meteor-spk-0.5.1.tar.xz),
+   [the binary distribution](https://dl.sandstorm.io/meteor-spk-0.6.0.tar.xz),
    e.g.:
 
         mkdir -p ~/projects/meteor-spk
         cd ~/projects/meteor-spk
-        curl https://dl.sandstorm.io/meteor-spk-0.5.1.tar.xz | tar Jxf -
-        cd meteor-spk-0.5.1
+        curl https://dl.sandstorm.io/meteor-spk-0.6.0.tar.xz | tar Jxf -
+        cd meteor-spk-0.6.0
 
 2. Add the directory to your `$PATH`, or symlink the `meteor-spk` script into
    a directory in your `$PATH`, e.g.:


### PR DESCRIPTION
...to the latest version of meteor.

Notably, this version of meteor uses node 14, so it is important to
update this now that sandstorm is running on it, so gather-deps.sh
doesn't pull in a version of node-capnp built for an incompatible
version of node.

---

I had hoped this would fix some of the 19 failures we're seeing on the Sandstorm test suite, but it does not. Still, worth doing, esp. since @xet7 is wanting to upgrade it for wekan.

I couldn't get mongo & niscu to build; for testing I copied the binaries from 0.5.1; I'll leave putting a release tarball to @kentonv.