### PR TITLE
Fixed fibers error when building .spk package with WeKan, Meteor 2.2, Node.js 14.x of meteor-spk-0.6.0

### DIFF
--- a/meteor-spk
+++ b/meteor-spk
@@ -70,7 +70,7 @@ bundle() {
   echo "Building Meteor app..."
   meteor npm install
   meteor build --directory .meteor-spk
-  (cd .meteor-spk/bundle/programs/server && meteor npm install)
+  (cd .meteor-spk/bundle/programs/server && meteor npm install && cd node_modules/fibers && node build.js)
 }
 
 case "$COMMAND" in


### PR DESCRIPTION
Fixed fibers error when building .spk package with WeKan, Meteor 2.2, Node.js 14.x of meteor-spk-0.6.0 .

Thanks to xet7 !

Fixes https://github.com/sandstorm-io/sandstorm/issues/3600